### PR TITLE
Bump json dep for snyk vuln

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     recaptcha (5.0.0)
-      json
+      json (>= 2.3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -11,7 +11,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
     bump (0.8.0)
-    byebug (11.0.1)
+    byebug (11.1.3)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crack (0.4.3)
@@ -20,7 +20,7 @@ GEM
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.2)
-    json (2.2.0)
+    json (2.9.1)
     maxitest (3.1.0)
       minitest (>= 5.0.0, < 5.12.0)
     metaclass (0.0.4)
@@ -60,6 +60,7 @@ PLATFORMS
 
 DEPENDENCIES
   bump
+  byebug (>= 11.1.3)
   i18n
   maxitest
   mocha
@@ -70,4 +71,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.0.1
+   2.5.9

--- a/recaptcha.gemspec
+++ b/recaptcha.gemspec
@@ -14,12 +14,13 @@ Gem::Specification.new do |s|
 
   s.files       = `git ls-files lib README.md CHANGELOG.md LICENSE`.split("\n")
 
-  s.add_runtime_dependency "json"
+  s.add_runtime_dependency "json", '>= 2.3.0'
   s.add_development_dependency "mocha"
   s.add_development_dependency "rake"
   s.add_development_dependency "i18n"
   s.add_development_dependency "maxitest"
   s.add_development_dependency "pry-byebug"
+  s.add_development_dependency "byebug", '>= 11.1.3'
   s.add_development_dependency "bump"
   s.add_development_dependency "webmock"
   s.add_development_dependency "rubocop"


### PR DESCRIPTION
Snyk Vulnerability for JSON Dependency

<img width="1490" alt="image" src="https://github.com/user-attachments/assets/87f69866-8b7a-4e29-9f44-533d98af56e3" />


Snyk reported a [vulnerability with this repo](https://app.snyk.io/org/content-discovery-and-library-management/project/9d45d579-1e1b-4ff6-bbcb-f11c474c60fb#issue-SNYK-RUBY-JSON-560838) due to the Gemfile.lock version of the json gem dependency. This repo is a forked version of the json gem and does not run on its own so we don't actually run the vulnerable version. Boulder runs a higher version of the json gem anyway due to other dependencies and no other repos use this version of the gem. However, to avoid potential future conflicts, I've added specifications to require at least the version of the json gem that fixes the vulnerability. 

I tested bundling pointing at this branch and confirmed it had no effect on Boulder other than adding the note of the high json requirement in Gemfile.lock but the actual version used is unchanged because it already fits the higher version restriction.

<img width="1288" alt="image" src="https://github.com/user-attachments/assets/3d8a8799-5730-4cf3-8adc-a3093e5b8bbf" />


I also had to update byebug because [m2 macs had an install issue](https://github.com/deivid-rodriguez/byebug/issues/849) with the version that had been specified. I figure its not a big deal to also bump byebug and if we need to do more work here in the future, we should be set to start work.